### PR TITLE
Onboard computer button, functional second seat, wagon names

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,7 +38,7 @@ advtrains.register_wagon("diesel_lokomotive", {
 			driving_ctrl_access = false,
 		},
 	},
-	assign_to_seat_group = {"dstand"},
+	assign_to_seat_group = {"dstand", "tseat"},
 	visual_size = {x=1, y=1},
 	wagon_span = 1.95,
 	collisionbox = {-1.0,-0.5,-1.0, 1.0,2.5,1.0},

--- a/init.lua
+++ b/init.lua
@@ -17,14 +17,12 @@ advtrains.register_wagon("diesel_lokomotive", {
 			name=S("Driver Stand (left)"),
 			attach_offset={x=-3, y=12, z=-2},
 			view_offset={x=0, y=3, z=0},
-			driving_ctrl_access=true,
 			group = "dstand",
 		},
 -- 		{
 -- 			name=S("Driver Stand (right)"),
 -- 			attach_offset={x=5, y=10, z=-10},
 -- 			view_offset={x=0, y=6, z=0},
--- 			driving_ctrl_access=true,
 -- 			group = "dstand",
 -- 		},
 	},
@@ -32,6 +30,7 @@ advtrains.register_wagon("diesel_lokomotive", {
 		dstand={
 			name = "Driver Stand",
 			access_to = {},
+			driving_ctrl_access=true,
 		},
 	},
 	assign_to_seat_group = {"dstand"},
@@ -73,7 +72,7 @@ advtrains.register_wagon("diesel_lokomotive", {
 	end,
 	drops={"advtrains:diesel_lokomotive"},
       horn_sound = "advtrains_engine_diesel_horn"
-}, S("diesel Engine"), "advtrains_engine_diesel_inv.png")
+}, S("Diesel Engine"), "advtrains_engine_diesel_inv.png")
 
 advtrains.register_wagon("wagon_gravel", {
 	mesh="advtrains_wagon_gravel.b3d",
@@ -95,7 +94,7 @@ advtrains.register_wagon("wagon_gravel", {
 	inventory_list_sizes = {
 		box=8*6,
 	},
-}, S("gravel Wagon"), "advtrains_wagon_gravel_inv.png")
+}, S("Gravel Wagon"), "advtrains_wagon_gravel_inv.png")
 
 advtrains.register_wagon("wagon_track", {
 	mesh="advtrains_wagon_stick.b3d",
@@ -117,7 +116,7 @@ advtrains.register_wagon("wagon_track", {
 	inventory_list_sizes = {
 		box=8*6,
 	},
-}, S("track wagon"), "advtrains_wagon_track_inv.png")
+}, S("Track Wagon"), "advtrains_wagon_track_inv.png")
 
 
 
@@ -141,7 +140,7 @@ advtrains.register_wagon("wagon_lava", {
 	inventory_list_sizes = {
 		box=8*6,
 	},
-}, S("lava wagon"), "advtrains_wagon_lava_inv.png")
+}, S("Lava Wagon"), "advtrains_wagon_lava_inv.png")
 
 
 advtrains.register_wagon("wagon_tree", {
@@ -164,4 +163,4 @@ advtrains.register_wagon("wagon_tree", {
 	inventory_list_sizes = {
 		box=8*6,
 	},
-}, S("tree wagon"), "advtrains_wagon_tree_inv.png")
+}, S("Tree Wagon"), "advtrains_wagon_tree_inv.png")

--- a/init.lua
+++ b/init.lua
@@ -14,28 +14,33 @@ advtrains.register_wagon("diesel_lokomotive", {
 	max_speed=10,
 	seats = {
 		{
-			name=S("Driver Stand (left)"),
-			attach_offset={x=-3, y=12, z=-2},
-			view_offset={x=0, y=3, z=0},
+			name = S("Driver Stand (left)"),
+			attach_offset = {x=-3, y=12, z=-2},
+			view_offset = {x=-4, y=3, z=0},
 			group = "dstand",
 		},
--- 		{
--- 			name=S("Driver Stand (right)"),
--- 			attach_offset={x=5, y=10, z=-10},
--- 			view_offset={x=0, y=6, z=0},
--- 			group = "dstand",
--- 		},
+		{
+			name = S("Trainee Seat (right)"),
+			attach_offset = {x=3, y=12, z=-2},
+			view_offset = {x=4, y=3, z=0},
+			group = "tseat",
+		},
 	},
 	seat_groups = {
-		dstand={
+		dstand = {
 			name = "Driver Stand",
-			access_to = {},
-			driving_ctrl_access=true,
+			access_to = {"tseat"},
+			driving_ctrl_access = true,
+		},
+		tseat = {
+			name = "Trainee Seat",
+			access_to = {"dstand"},
+			driving_ctrl_access = false,
 		},
 	},
 	assign_to_seat_group = {"dstand"},
 	visual_size = {x=1, y=1},
-	wagon_span=1.95,
+	wagon_span = 1.95,
 	collisionbox = {-1.0,-0.5,-1.0, 1.0,2.5,1.0},
 	update_animation=function(self, velocity)
 		if self.old_anim_velocity~=advtrains.abs_ceil(velocity) then
@@ -71,7 +76,7 @@ advtrains.register_wagon("diesel_lokomotive", {
 		})
 	end,
 	drops={"advtrains:diesel_lokomotive"},
-      horn_sound = "advtrains_engine_diesel_horn"
+      horn_sound = "advtrains_engine_diesel_horn",
 }, S("Diesel Engine"), "advtrains_engine_diesel_inv.png")
 
 advtrains.register_wagon("wagon_gravel", {


### PR DESCRIPTION
This change enables the on-board computer access button (super-useful for a shunter) and changes the names of the wagons to be consistently capitalized.

UPD: I also enabled the second (trainee) seat on the diesel locomotive, and adjusted both seats positions, so that people stand side-by-side and yet look out of the cabin's windows in the front. With the previous view offset the train was best driven in 3rd person view...